### PR TITLE
Add create_index to tfrecord2idx

### DIFF
--- a/tfrecord/tools/tfrecord2idx.py
+++ b/tfrecord/tools/tfrecord2idx.py
@@ -3,13 +3,9 @@ import sys
 import struct
 
 
-def main():
-    if len(sys.argv) < 3:
-        print("Usage: tfrecord2idx <tfrecord path> <index path>")
-        exit()
-
-    infile = open(sys.argv[1], "rb")
-    outfile = open(sys.argv[2], "w")
+def create_index(tfrecord_file, index_file):
+    infile = open(tfrecord_file, "rb")
+    outfile = open(index_file, "w")
 
     while True:
         current = infile.tell()
@@ -28,6 +24,14 @@ def main():
 
     infile.close()
     outfile.close()
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: tfrecord2idx <tfrecord path> <index path>")
+        exit()
+
+    create_index(sys.argv[1], sys.argv[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows users to do stuff like

`from tfrecord.tools.tfrecord2idx import create_index`

And then create indices on the fly if they don't exist.

Especially useful when used in a pyspark environment, where there are 100+ tfrecord files created but indices have to be created.