### PR TITLE
fix resizing `datum_bytes`

### DIFF
--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -28,6 +28,8 @@ def tfrecord_iterator(data_path, index_path=None, shard=None):
     datum_bytes = bytearray(1024*1024)
 
     def read_records(start_offset=None, end_offset=None):
+        nonlocal length_bytes, crc_bytes, datum_bytes
+
         if start_offset is not None:
             file.seek(start_offset)
         if end_offset is None:
@@ -39,7 +41,7 @@ def tfrecord_iterator(data_path, index_path=None, shard=None):
                 raise RuntimeError("Failed to read the start token.")
             length, = struct.unpack("<Q", length_bytes)
             if length > len(datum_bytes):
-                datum_bytes.zfill(int(length * 1.5))
+                datum_bytes = datum_bytes.zfill(int(length * 1.5))
             datum_bytes_view = memoryview(datum_bytes)[:length]
             if file.readinto(datum_bytes_view) != length:
                 raise RuntimeError("Failed to read the record.")


### PR DESCRIPTION
The `bytearray.zfill(N)` function creates a copy of the array filled with zeroes to `N` bytes. The source array is unchanged.
https://docs.python.org/3.6/library/stdtypes.html#str.zfill

With this change, the `datum_bytes` is reset to the extended array.