### PR TITLE
Add ability to transform input

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,39 @@ loader = tfrecord.tfrecord_loader("/path/to/data.tfrecord", None, {
 for record in loader:
     print(record["label"])
 ```
+
+### Transforming input
+
+There are use cases when you might not want to return your input directly after reading from the tfrecord files.
+A trivial example could be to normalize your input, if you haven't saved the normalized feature in the files.
+
+You can easily achieve this by leveraging the `transform_func` argument.
+There might also be use cases to remove a field after performing a transformation, this can be leveraged using the `removed_fields`.
+
+Both the arguments mentioned above are available in all readers including `tfrecord.tfrecord_loader` and `tfrecord.torch.TFRecordDataset`.
+ 
+```python
+import tfrecord
+
+def transformation(features):
+    # modify an existing feature
+    features["feature_1"] = features["feature_1"] * 2
+    # create a new feature
+    features["feature_2"] = features["index"] * 4
+    return features
+
+
+description = {
+    "index": "int",
+    "feature_1": "float",
+}
+
+dataset = tfrecord.torch.TFRecordDataset("/path/to/data.tfrecord",
+                                         index_path=None,
+                                         transform_func=transformation,
+                                         removed_fields=["index"])
+
+data = next(iter(dataset))
+
+assert set(data.keys()) == {"feature_1", "feature_2"}, "Expected keys don't match."
+```

--- a/README.md
+++ b/README.md
@@ -77,13 +77,9 @@ for record in loader:
 
 ### Transforming input
 
-There are use cases when you might not want to return your input directly after reading from the tfrecord files.
-A trivial example could be to normalize your input, if you haven't saved the normalized feature in the files.
-
-You can easily achieve this by leveraging the `transform_func` argument.
+You can optionally pass a function as `transform` argument to perform post processing of features before returning. 
+This can for example be used to decode images or normalize colors to a certain range
 There might also be use cases to remove a field after performing a transformation, this can be leveraged using the `removed_fields`.
-
-Both the arguments mentioned above are available in all readers including `tfrecord.tfrecord_loader` and `tfrecord.torch.TFRecordDataset`.
  
 ```python
 import tfrecord
@@ -103,7 +99,7 @@ description = {
 
 dataset = tfrecord.torch.TFRecordDataset("/path/to/data.tfrecord",
                                          index_path=None,
-                                         transform_func=transformation,
+                                         transform=transformation,
                                          removed_fields=["index"])
 
 data = next(iter(dataset))

--- a/README.md
+++ b/README.md
@@ -78,31 +78,27 @@ for record in loader:
 ### Transforming input
 
 You can optionally pass a function as `transform` argument to perform post processing of features before returning. 
-This can for example be used to decode images or normalize colors to a certain range
-There might also be use cases to remove a field after performing a transformation, this can be leveraged using the `removed_fields`.
+This can for example be used to decode images or normalize colors to a certain range or pad variable length sequence.
  
 ```python
 import tfrecord
+import cv2
 
-def transformation(features):
-    # modify an existing feature
-    features["feature_1"] = features["feature_1"] * 2
-    # create a new feature
-    features["feature_2"] = features["index"] * 4
+def decode_image(features):
+    # get BGR image from bytes
+    features["image"] = cv2.imdecode(features["image"], -1)
     return features
 
 
 description = {
-    "index": "int",
-    "feature_1": "float",
+    "image": "bytes",
 }
 
 dataset = tfrecord.torch.TFRecordDataset("/path/to/data.tfrecord",
                                          index_path=None,
-                                         transform=transformation,
-                                         removed_fields=["index"])
+                                         description=description,
+                                         transform=decode_image)
 
 data = next(iter(dataset))
-
-assert set(data.keys()) == {"feature_1", "feature_2"}, "Expected keys don't match."
+print(data)
 ```

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires += ["numpy", "protobuf"]
 
 setup(
     name="tfrecord",
-    version="1.11",
+    version="1.10",
     description="TFRecord reader",
     author="Vahid Kazemi",
     author_email="vkazemi@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires += ["numpy", "protobuf"]
 
 setup(
     name="tfrecord",
-    version="1.10",
+    version="1.11",
     description="TFRecord reader",
     author="Vahid Kazemi",
     author_email="vkazemi@gmail.com",

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -107,7 +107,7 @@ def tfrecord_loader(data_path: str,
     data_path: str
         TFRecord file path.
 
-    index_path: str
+    index_path: str or None
         Index file path. Can be set to None if no file is available.
 
     description: list or dict of str, optional, default=None
@@ -215,7 +215,7 @@ def multi_tfrecord_loader(data_pattern: str,
     data_pattern: str
         Input data path pattern.
 
-    index_pattern: str
+    index_pattern: str or None
         Input index path pattern.
 
     splits: dict

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -93,7 +93,7 @@ def tfrecord_loader(data_path: str,
                     index_path: typing.Union[str, None],
                     description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                     shard: typing.Optional[typing.Tuple[int, int]] = None,
-                    transform_func: typing.Callable[[dict], typing.Any] = None,
+                    transform: typing.Callable[[dict], typing.Any] = None,
                     removed_fields: typing.List[str] = None
                     ) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
     """Create an iterator over the (decoded) examples contained within
@@ -143,7 +143,7 @@ def tfrecord_loader(data_path: str,
         depending on the transformation.
     """
 
-    transform_func = transform_func or (lambda x: x)
+    transform = transform or (lambda x: x)
     removed_fields = removed_fields or []
 
     different_keys = set(removed_fields) - description.keys()
@@ -192,7 +192,7 @@ def tfrecord_loader(data_path: str,
                 value = np.array(value, dtype=np.int32)
             features[key] = value
 
-        features_to_return = transform_func(features)
+        features_to_return = transform(features)
         for key in removed_fields:
             if key in removed_fields:
                 features_to_return.pop(key)
@@ -204,7 +204,7 @@ def multi_tfrecord_loader(data_pattern: str,
                           index_pattern: typing.Union[str, None],
                           splits: typing.Dict[str, float],
                           description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                          transform_func: typing.Callable[[dict], typing.Any] = None,
+                          transform: typing.Callable[[dict], typing.Any] = None,
                           removed_fields: typing.List[str] = None) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
     """Create an iterator by reading and merging multiple tfrecord datasets.
 
@@ -243,7 +243,7 @@ def multi_tfrecord_loader(data_pattern: str,
                                  index_path=index_pattern.format(split) \
                                      if index_pattern is not None else None,
                                  description=description,
-                                 transform_func=transform_func,
+                                 transform=transform,
                                  removed_fields=removed_fields)
                for split in splits.keys()]
     return iterator_utils.sample_iterators(loaders, list(splits.values()))

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -128,13 +128,6 @@ def tfrecord_loader(data_path: str,
         an individual record).
     """
 
-    transform = transform or (lambda x: x)
-    removed_fields = removed_fields or []
-
-    different_keys = set(removed_fields) - description.keys()
-
-    assert len(different_keys) == 0, f"Extra keys in different_keys : '{', '.join(different_keys)}'"
-
     typename_mapping = {
         "byte": "bytes_list",
         "float": "float_list",

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -90,11 +90,11 @@ def tfrecord_iterator(data_path: str,
 
 
 def tfrecord_loader(data_path: str,
-                    index_path: str,
+                    index_path: typing.Union[str, None],
                     description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                     shard: typing.Optional[typing.Tuple[int, int]] = None,
                     transform_func: typing.Callable[[dict], typing.Any] = None,
-                    removed_fields: typing.List[str] = None,
+                    removed_fields: typing.List[str] = None
                     ) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
     """Create an iterator over the (decoded) examples contained within
     the dataset.
@@ -201,7 +201,7 @@ def tfrecord_loader(data_path: str,
 
 
 def multi_tfrecord_loader(data_pattern: str,
-                          index_pattern: str,
+                          index_pattern: typing.Union[str, None],
                           splits: typing.Dict[str, float],
                           description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                           transform_func: typing.Callable[[dict], typing.Any] = None,
@@ -215,7 +215,7 @@ def multi_tfrecord_loader(data_pattern: str,
     data_pattern: str
         Input data path pattern.
 
-    index_pattern: str, optional, default=None
+    index_pattern: str
         Input index path pattern.
 
     splits: dict

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -18,7 +18,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
     data_path: str
         The path to the tfrecords file.
 
-    index_path: str
+    index_path: str or None
         The path to the index file.
 
     description: list or dict of str, optional, default=None
@@ -47,7 +47,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
 
     def __init__(self,
                  data_path: str,
-                 index_path: str,
+                 index_path: typing.Union[str, None],
                  description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                  shuffle_queue_size: typing.Optional[int] = None,
                  transform_func: typing.Callable[[dict], typing.Any] = None,
@@ -119,7 +119,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
 
     def __init__(self,
                  data_pattern: str,
-                 index_pattern: str,
+                 index_pattern: typing.Union[str, None],
                  splits: typing.Dict[str, float],
                  description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                  shuffle_queue_size: typing.Optional[int] = None) -> None:

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -33,7 +33,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
         Length of buffer. Determines how many records are queued to
         sample from.
 
-    transform_func : a callable, default = None
+    transform : a callable, default = None
         A function that takes in the input `features` i.e the dict
         provided in the description and returns a desirable output.
         It's useful for having transformation on our input to get
@@ -50,7 +50,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
                  index_path: typing.Union[str, None],
                  description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                  shuffle_queue_size: typing.Optional[int] = None,
-                 transform_func: typing.Callable[[dict], typing.Any] = None,
+                 transform: typing.Callable[[dict], typing.Any] = None,
                  removed_fields: typing.List[str] = None,
                  ) -> None:
         super(TFRecordDataset, self).__init__()
@@ -58,7 +58,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
         self.index_path = index_path
         self.description = description
         self.shuffle_queue_size = shuffle_queue_size
-        self.transform_func = transform_func
+        self.transform_func = transform
         self.removed_fields = removed_fields
 
     def __iter__(self):
@@ -70,7 +70,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
             shard = None
         it = reader.tfrecord_loader(
             self.data_path, self.index_path, self.description, shard,
-            transform_func=self.transform_func, removed_fields=self.removed_fields)
+            transform=self.transform_func, removed_fields=self.removed_fields)
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)
         return it
@@ -105,7 +105,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
         Length of buffer. Determines how many records are queued to
         sample from.
 
-        transform_func : a callable, default = None
+    transform : a callable, default = None
         A function that takes in the input `features` i.e the dict
         provided in the description and returns a desirable output.
         It's useful for having transformation on our input to get
@@ -122,13 +122,17 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
                  index_pattern: typing.Union[str, None],
                  splits: typing.Dict[str, float],
                  description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                 shuffle_queue_size: typing.Optional[int] = None) -> None:
+                 shuffle_queue_size: typing.Optional[int] = None,
+                 transform: typing.Callable[[dict], typing.Any] = None,
+                 removed_fields: typing.List[str] = None) -> None:
         super(MultiTFRecordDataset, self).__init__()
         self.data_pattern = data_pattern
         self.index_pattern = index_pattern
         self.splits = splits
         self.description = description
         self.shuffle_queue_size = shuffle_queue_size
+        self.transform_func = transform
+        self.removed_fields = removed_fields
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -136,7 +140,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
             np.random.seed(worker_info.seed % np.iinfo(np.uint32).max)
         it = reader.multi_tfrecord_loader(
             self.data_pattern, self.index_pattern, self.splits, self.description,
-            transform_func=self.transform_func, removed_fields=self.removed_fields)
+            transform=self.transform_func, removed_fields=self.removed_fields)
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)
         return it

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -45,16 +45,13 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
                  index_path: typing.Union[str, None],
                  description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                  shuffle_queue_size: typing.Optional[int] = None,
-                 transform: typing.Callable[[dict], typing.Any] = None,
-                 removed_fields: typing.List[str] = None,
+                 transform: typing.Callable[[dict], typing.Any] = None
                  ) -> None:
         super(TFRecordDataset, self).__init__()
         self.data_path = data_path
         self.index_path = index_path
         self.description = description
         self.shuffle_queue_size = shuffle_queue_size
-        self.transform_func = transform
-        self.removed_fields = removed_fields
         self.transform = transform or (lambda x: x)
 
     def __iter__(self):

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -65,8 +65,9 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
             self.data_path, self.index_path, self.description, shard)
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)
-
-        return map(self.transform, it)
+        if self.transform:
+            it = map(self.transform, it)
+        return it
 
 
 class MultiTFRecordDataset(torch.utils.data.IterableDataset):
@@ -118,7 +119,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
         self.splits = splits
         self.description = description
         self.shuffle_queue_size = shuffle_queue_size
-        self.transform = transform or (lambda x: x)
+        self.transform = transform
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -128,5 +129,6 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
             self.data_pattern, self.index_pattern, self.splits, self.description)
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)
-
-        return map(self.transform, it)
+        if self.transform:
+            it = map(self.transform, it)
+        return it

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -85,7 +85,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
     data_pattern: str
         Input data path pattern.
 
-    index_pattern: str
+    index_pattern: str or None
         Input index path pattern.
 
     splits: dict


### PR DESCRIPTION
Right now the library only supports fetching from `tfrecord` files and yielding it to be consumed as a `torch.Tensor`. However there are several use cases when transformation is necessary.

This also helps maintain consistency with the regular `torch.utils.data.Dataset`, where one implements the [transform func inside the `__getitem__` function](https://github.com/pytorch/tutorials/blob/a8035e7b098437a672029499dc4c3e83396fbd36/beginner_source/data_loading_tutorial.py#L152).

One of the other libraries that I have used in the past is petastorm and they have a similar [interface for providing `TransformSpec`.](https://github.com/uber/petastorm#pytorch-api).

Example use cases
1. Normalize features
1. Pad features
1. Save only indexes for categorical values and look them up from a dict to save I/O.


I added code in readme for understanding the use case. 
