### PR TITLE
Reading `SequenceExample` TFRecords

### DIFF
--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -91,7 +91,8 @@ def tfrecord_iterator(data_path: str,
 
 def process_feature(feature: example_pb2.Feature,
                     typename: str,
-                    typename_mapping: dict):
+                    typename_mapping: dict,
+                    key: str):
     # NOTE: We assume that each key in the example has only one field
     # (either "bytes_list", "float_list", or "int64_list")!
     field = feature.ListFields()[0]
@@ -124,7 +125,7 @@ def extract_features(features, description, typename_mapping):
     for key, typename in description.items():
         if key not in all_keys:
             raise KeyError(f"Key {key} doesn't exist (select from {all_keys})!")
-        processed_features[key] = process_feature(features[key], typename, typename_mapping)
+        processed_features[key] = process_feature(features[key], typename, typename_mapping, key)
 
     return processed_features
 
@@ -143,7 +144,7 @@ def extract_feature_lists(feature_lists: example_pb2.FeatureLists, description, 
         # NOTE: We assume that each key in the example has only one field
         # (either "bytes_list", "float_list", or "int64_list")!
         feature = feature_lists.feature_list[key].feature
-        fn = functools.partial(process_feature, typename=typename, typename_mapping=typename_mapping)
+        fn = functools.partial(process_feature, typename=typename, typename_mapping=typename_mapping, key=key)
         processed_features[key] = np.array(list(map(fn, feature)))
 
     return processed_features

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -149,11 +149,11 @@ def extract_feature_lists(feature_lists: example_pb2.FeatureLists, description, 
     return processed_features
 
 
-def tfrecord_example_loader(data_path: str,
-                    index_path: typing.Union[str, None],
-                    description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                    shard: typing.Optional[typing.Tuple[int, int]] = None,
-                    ) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
+def example_loader(data_path: str,
+                   index_path: typing.Union[str, None],
+                   description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+                   shard: typing.Optional[typing.Tuple[int, int]] = None,
+                   ) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
     """Create an iterator over the (decoded) examples contained within
     the dataset.
 
@@ -203,7 +203,7 @@ def tfrecord_example_loader(data_path: str,
         yield extract_features(example.features.feature, description, typename_mapping)
 
 
-def tfrecord_sequence_loader(data_path: str,
+def sequence_loader(data_path: str,
                     index_path: typing.Union[str, None],
                     context_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                     features_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
@@ -265,7 +265,7 @@ def tfrecord_loader(data_path: str,
         Decoded bytes of the features into its respective data type (for
         an individual record).
     """
-    return tfrecord_example_loader(data_path, index_path, description, shard)
+    return example_loader(data_path, index_path, description, shard)
 
 
 def multi_tfrecord_loader(data_pattern: str,

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -89,17 +89,6 @@ def tfrecord_iterator(data_path: str,
     file.close()
 
 
-def decode_bytes(inferred_typename: str, value):
-    # Decode raw bytes into respective data types
-    if inferred_typename == "bytes_list":
-        value = np.frombuffer(value[0], dtype=np.uint8)
-    elif inferred_typename == "float_list":
-        value = np.array(value, dtype=np.float32)
-    elif inferred_typename == "int64_list":
-        value = np.array(value, dtype=np.int32)
-    return value
-
-
 def process_feature(feature: example_pb2.Feature,
                     typename: str,
                     typename_mapping: dict):
@@ -115,7 +104,13 @@ def process_feature(feature: example_pb2.Feature,
             raise TypeError(f"Incompatible type '{typename}' for `{key}` "
                         f"(should be '{reversed_mapping[inferred_typename]}').")
 
-    return decode_bytes(inferred_typename, value)
+    if inferred_typename == "bytes_list":
+        value = np.frombuffer(value[0], dtype=np.uint8)
+    elif inferred_typename == "float_list":
+        value = np.array(value, dtype=np.float32)
+    elif inferred_typename == "int64_list":
+        value = np.array(value, dtype=np.int32)
+    return value
 
 
 def extract_features(features, description, typename_mapping):

--- a/tfrecord/writer.py
+++ b/tfrecord/writer.py
@@ -29,16 +29,31 @@ class TFRecordWriter:
         """Close the tfrecord file."""
         self.file.close()
 
-    def write(self, datum: typing.Dict[str, typing.Tuple[typing.Any, str]]) -> None:
-        """Write an example into tfrecord file.
+    def write(self, datum: typing.Dict[str, typing.Tuple[typing.Any, str]],
+              sequence_datum: typing.Union[typing.Dict[str, typing.Tuple[typing.List[typing.Any], str]], None] = None,
+              ) -> None:
+        """Write an example into tfrecord file. Either as a Example
+        SequenceExample depending on the presence of `sequence_datum`.
+        If `sequence_datum` is None (by default), this writes a Example
+        to file. Otherwise, it writes a SequenceExample to file, assuming
+        `datum` to be the context and `sequence_datum` to be the sequential
+        features.
 
         Params:
         -------
         datum: dict
             Dictionary of tuples of form (value, dtype). dtype can be
             "byte", "float" or "int".
+        sequence_datum: dict
+            By default, it is set to None. If this value is present, then the
+            Dictionary of tuples of the form (value, dtype). dtype can be
+            "byte", "float" or "int". value should be the sequential features.
         """
-        record = TFRecordWriter.serialize_tf_example(datum)
+        if sequence_datum is None:
+            record = TFRecordWriter.serialize_tf_example(datum)
+        else:
+            record = TFRecordWriter.serialize_tf_sequence_example(datum, sequence_datum)
+
         length = len(record)
         length_bytes = struct.pack("<Q", length)
         self.file.write(length_bytes)
@@ -90,7 +105,25 @@ class TFRecordWriter:
         return example_proto.SerializeToString()
 
     @staticmethod
-    def serialize_tf_sequence_example(c_datum, f_datum):
+    def serialize_tf_sequence_example(context_datum: typing.Dict[str, typing.Tuple[typing.Any, str]],
+                                      features_datum: typing.Dict[str, typing.Tuple[typing.List[typing.Any], str]],
+                                      ) -> bytes:
+        """Serialize sequence example into tfrecord.SequenceExample proto.
+
+        Params:
+        -------
+        context_datum: dict
+            Dictionary of tuples of form (value, dtype). dtype can be
+            "byte", "float" or int.
+
+        features_datum: dict
+            Same as `context_datum`, but for the features.
+
+        Returns:
+        --------
+        proto: bytes
+            Serialized tfrecord.SequenceExample to bytes.
+        """
         feature_map = {
             "byte": lambda f: example_pb2.Feature(
                 bytes_list=example_pb2.BytesList(value=f)),
@@ -111,8 +144,8 @@ class TFRecordWriter:
                 feature_list.feature.append(serialize(v, dtype))
             return feature_list
 
-        context = {key: serialize(value, dtype) for key, (value, dtype) in c_datum.items()}
-        features = {key: serialize_repeated(value, dtype) for key, (value, dtype) in f_datum.items()}
+        context = {key: serialize(value, dtype) for key, (value, dtype) in context_datum.items()}
+        features = {key: serialize_repeated(value, dtype) for key, (value, dtype) in features_datum.items()}
 
         context = example_pb2.Features(feature=context)
         features = example_pb2.FeatureLists(feature_list=features)


### PR DESCRIPTION
This PR adds the ability to read a `SequenceExample` TFRecords file. Currently, when trying to read such a file, only the context portion and not the features gets read. 

I'm currently working on improving the code which I wrote. To make sure I haven't broken anything and all works as expected.

Any feedback which you can give me to help improve and get the code in a state to be merged would be greatly appreciated.