### PR TITLE
Add support for gzipped files to TFRecordDataset

### DIFF
--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -364,8 +364,21 @@ def tfrecord_loader(
         instance of a `SequenceExample`.
     """
     if sequence_description is not None:
-        return sequence_loader(data_path, index_path, description, sequence_description, shard, compression_type)
-    return example_loader(data_path, index_path, description, shard, compression_type)
+        return sequence_loader(
+            data_path=data_path,
+            index_path=index_path,
+            context_description=description,
+            features_description=sequence_description,
+            shard=shard,
+            compression_type=compression_type
+        )
+    return example_loader(
+        data_path=data_path,
+        index_path=index_path,
+        description=description,
+        shard=shard,
+        compression_type=compression_type
+    )
 
 
 def multi_tfrecord_loader(data_pattern: str,

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -364,7 +364,7 @@ def tfrecord_loader(
         instance of a `SequenceExample`.
     """
     if sequence_description is not None:
-        return sequence_loader(data_path, index_path, description, sequence_description, shard)
+        return sequence_loader(data_path, index_path, description, sequence_description, shard, compression_type)
     return example_loader(data_path, index_path, description, shard, compression_type)
 
 

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -44,7 +44,7 @@ def tfrecord_iterator(
         Object referencing the specified `datum_bytes` contained in the
         file (for a single record).
     """
-    if compression_type is "gzip":
+    if compression_type == "gzip":
         file = gzip.open(data_path, "rb")
     elif compression_type is None:
         file = io.open(data_path, "rb")
@@ -209,7 +209,12 @@ def example_loader(
         "int": "int64_list"
     }
 
-    record_iterator = tfrecord_iterator(data_path, index_path, shard, compression_type)
+    record_iterator = tfrecord_iterator(
+        data_path=data_path,
+        index_path=index_path,
+        shard=shard,
+        compression_type=compression_type,
+    )
 
     for record in record_iterator:
         example = example_pb2.Example()
@@ -287,7 +292,12 @@ def sequence_loader(
         "int": "int64_list"
     }
 
-    record_iterator = tfrecord_iterator(data_path, index_path, shard, compression_type)
+    record_iterator = tfrecord_iterator(
+        data_path=data_path,
+        index_path=index_path,
+        shard=shard,
+        compression_type=compression_type,
+    )
 
     for record in record_iterator:
         example = example_pb2.SequenceExample()
@@ -386,6 +396,7 @@ def multi_tfrecord_loader(data_pattern: str,
                           splits: typing.Dict[str, float],
                           description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                           sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+                          compression_type: typing.Optional[str] = None,
                           ) -> typing.Iterable[typing.Union[typing.Dict[str, np.ndarray],
                                                             typing.Tuple[typing.Dict[str, np.ndarray],
                                                                          typing.Dict[str, typing.List[np.ndarray]]]]]:
@@ -421,6 +432,10 @@ def multi_tfrecord_loader(data_pattern: str,
         `SequenceExample` is read. If an empty list or dictionary is
         passed, then all features contained in the file are extracted.
 
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
+
     Returns:
     --------
     it: iterator
@@ -431,6 +446,7 @@ def multi_tfrecord_loader(data_pattern: str,
                                      if index_pattern is not None else None,
                                  description=description,
                                  sequence_description=sequence_description,
+                                 compression_type=compression_type,
                                  )
                for split in splits.keys()]
     return iterator_utils.sample_iterators(loaders, list(splits.values()))

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -1,6 +1,7 @@
 """Reader utils."""
 
 import functools
+import gzip
 import io
 import os
 import struct
@@ -12,10 +13,12 @@ from tfrecord import example_pb2
 from tfrecord import iterator_utils
 
 
-def tfrecord_iterator(data_path: str,
-                      index_path: typing.Optional[str] = None,
-                      shard: typing.Optional[typing.Tuple[int, int]] = None
-                      ) -> typing.Iterable[memoryview]:
+def tfrecord_iterator(
+    data_path: str,
+    index_path: typing.Optional[str] = None,
+    shard: typing.Optional[typing.Tuple[int, int]] = None,
+    compression_type: typing.Optional[str] = None,
+) -> typing.Iterable[memoryview]:
     """Create an iterator over the tfrecord dataset.
 
     Since the tfrecords file stores each example as bytes, we can
@@ -41,8 +44,12 @@ def tfrecord_iterator(data_path: str,
         Object referencing the specified `datum_bytes` contained in the
         file (for a single record).
     """
-    file = io.open(data_path, "rb")
-
+    if compression_type is "gzip":
+        file = gzip.open(data_path, "rb")
+    elif compression_type is None:
+        file = io.open(data_path, "rb")
+    else:
+        raise ValueError("compression_type should be either 'gzip' or None")
     length_bytes = bytearray(8)
     crc_bytes = bytearray(4)
     datum_bytes = bytearray(1024 * 1024)
@@ -151,11 +158,13 @@ def extract_feature_dict(features, description, typename_mapping):
     return processed_features
 
 
-def example_loader(data_path: str,
-                   index_path: typing.Union[str, None],
-                   description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                   shard: typing.Optional[typing.Tuple[int, int]] = None,
-                   ) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
+def example_loader(
+    data_path: str,
+    index_path: typing.Union[str, None],
+    description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+    shard: typing.Optional[typing.Tuple[int, int]] = None,
+    compression_type: typing.Optional[str] = None,
+) -> typing.Iterable[typing.Dict[str, np.ndarray]]:
     """Create an iterator over the (decoded) examples contained within
     the dataset.
 
@@ -183,6 +192,10 @@ def example_loader(data_path: str,
         count. Necessary to evenly split/shard the dataset among many
         workers (i.e. >1).
 
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
+
     Yields:
     -------
     features: dict of {str, np.ndarray}
@@ -196,7 +209,7 @@ def example_loader(data_path: str,
         "int": "int64_list"
     }
 
-    record_iterator = tfrecord_iterator(data_path, index_path, shard)
+    record_iterator = tfrecord_iterator(data_path, index_path, shard, compression_type)
 
     for record in record_iterator:
         example = example_pb2.Example()
@@ -205,13 +218,22 @@ def example_loader(data_path: str,
         yield extract_feature_dict(example.features, description, typename_mapping)
 
 
-def sequence_loader(data_path: str,
-                    index_path: typing.Union[str, None],
-                    context_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                    features_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                    shard: typing.Optional[typing.Tuple[int, int]] = None,
-                    ) -> typing.Iterable[typing.Tuple[typing.Dict[str, np.ndarray],
-                                                      typing.Dict[str, typing.List[np.ndarray]]]]:
+def sequence_loader(
+    data_path: str,
+    index_path: typing.Union[str, None],
+    context_description: typing.Union[
+        typing.List[str], typing.Dict[str, str], None
+    ] = None,
+    features_description: typing.Union[
+        typing.List[str], typing.Dict[str, str], None
+    ] = None,
+    shard: typing.Optional[typing.Tuple[int, int]] = None,
+    compression_type: typing.Optional[str] = None,
+) -> typing.Iterable[
+    typing.Tuple[
+        typing.Dict[str, np.ndarray], typing.Dict[str, typing.List[np.ndarray]]
+    ]
+]:
     """Create an iterator over the (decoded) sequence examples contained within
     the dataset.
 
@@ -243,6 +265,10 @@ def sequence_loader(data_path: str,
         count. Necessary to evenly split/shard the dataset among many
         workers (i.e. >1).
 
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
+
     Yields:
     -------
     A tuple of (context, features) for an individual record.
@@ -261,7 +287,7 @@ def sequence_loader(data_path: str,
         "int": "int64_list"
     }
 
-    record_iterator = tfrecord_iterator(data_path, index_path, shard)
+    record_iterator = tfrecord_iterator(data_path, index_path, shard, compression_type)
 
     for record in record_iterator:
         example = example_pb2.SequenceExample()
@@ -273,14 +299,23 @@ def sequence_loader(data_path: str,
         yield context, features
 
 
-def tfrecord_loader(data_path: str,
-                    index_path: typing.Union[str, None],
-                    description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                    shard: typing.Optional[typing.Tuple[int, int]] = None,
-                    sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
-                    ) -> typing.Iterable[typing.Union[typing.Dict[str, np.ndarray],
-                                                      typing.Tuple[typing.Dict[str, np.ndarray],
-                                                                   typing.Dict[str, typing.List[np.ndarray]]]]]:
+def tfrecord_loader(
+    data_path: str,
+    index_path: typing.Union[str, None],
+    description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+    shard: typing.Optional[typing.Tuple[int, int]] = None,
+    sequence_description: typing.Union[
+        typing.List[str], typing.Dict[str, str], None
+    ] = None,
+    compression_type: typing.Optional[str] = None,
+) -> typing.Iterable[
+    typing.Union[
+        typing.Dict[str, np.ndarray],
+        typing.Tuple[
+            typing.Dict[str, np.ndarray], typing.Dict[str, typing.List[np.ndarray]]
+        ],
+    ]
+]:
     """Create an iterator over the (decoded) examples contained within
     the dataset.
 
@@ -316,6 +351,10 @@ def tfrecord_loader(data_path: str,
         `SequenceExample` is read. If an empty list or dictionary is
         passed, then all features contained in the file are extracted.
 
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
+
     Yields:
     -------
     features: dict of {str, value}
@@ -326,7 +365,7 @@ def tfrecord_loader(data_path: str,
     """
     if sequence_description is not None:
         return sequence_loader(data_path, index_path, description, sequence_description, shard)
-    return example_loader(data_path, index_path, description, shard)
+    return example_loader(data_path, index_path, description, shard, compression_type)
 
 
 def multi_tfrecord_loader(data_pattern: str,

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -47,6 +47,10 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
         `SequenceExample` is read. If an empty list or dictionary is
         passed, then all features contained in the file are extracted.
 
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
+
     """
 
     def __init__(self,
@@ -128,6 +132,9 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
         `SequenceExample` is read. If an empty list or dictionary is
         passed, then all features contained in the file are extracted.
 
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
     """
 
     def __init__(self,
@@ -138,6 +145,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
                  shuffle_queue_size: typing.Optional[int] = None,
                  transform: typing.Callable[[dict], typing.Any] = None,
                  sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+                 compression_type: typing.Optional[str] = None,
                  ) -> None:
         super(MultiTFRecordDataset, self).__init__()
         self.data_pattern = data_pattern
@@ -147,6 +155,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
         self.sequence_description = sequence_description
         self.shuffle_queue_size = shuffle_queue_size
         self.transform = transform
+        self.compression_type = compression_type
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -156,7 +165,9 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
                                           index_pattern=self.index_pattern,
                                           splits=self.splits,
                                           description=self.description,
-                                          sequence_description=self.sequence_description)
+                                          sequence_description=self.sequence_description,
+                                          compression_type=self.compression_type,
+                                         )
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)
         if self.transform:

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -56,6 +56,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
                  shuffle_queue_size: typing.Optional[int] = None,
                  transform: typing.Callable[[dict], typing.Any] = None,
                  sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+                 compression_type: typing.Optional[str] = None,
                  ) -> None:
         super(TFRecordDataset, self).__init__()
         self.data_path = data_path
@@ -64,6 +65,7 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
         self.sequence_description = sequence_description
         self.shuffle_queue_size = shuffle_queue_size
         self.transform = transform or (lambda x: x)
+        self.compression_type = compression_type
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -76,7 +78,8 @@ class TFRecordDataset(torch.utils.data.IterableDataset):
                                     index_path=self.index_path,
                                     description=self.description,
                                     shard=shard,
-                                    sequence_description=self.sequence_description)
+                                    sequence_description=self.sequence_description,
+                                    compression_type=self.compression_type)
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)
         if self.transform:


### PR DESCRIPTION
This adds support for reading TFRecordDatasets compressed with `gzip`. I didn't add it to the `MultiTFRecordDataset` since I didn't need it, but if you want to merge this into master, I'd be happy to make the changes.

I tested this by running the following script with a tfrecord compressed with `gzip` (I modified the paths and description to work for my compressed record which unfortunately contains data I can't share):
```
tfrecord_path = "/tmp/data.tfrecord"
index_path = None
description = {"image": "byte", "label": "float"}
dataset = TFRecordDataset(tfrecord_path, index_path, description)
loader = torch.utils.data.DataLoader(dataset, batch_size=32)

data = next(iter(loader))
print(data)
```

I used the following conda environment when testing:
```
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: osx-64
blas=1.0=mkl
bzip2=1.0.8=h1de35cc_0
ca-certificates=2021.5.25=hecd8cb5_1
certifi=2021.5.30=py39hecd8cb5_0
crc32c=2.2=py39hb5aae12_0
ffmpeg=4.3=h0a44026_0
freetype=2.10.4=ha233b18_0
gettext=0.21.0=h7535e17_0
gmp=6.2.1=h23ab428_2
gnutls=3.6.15=hed9c0bf_0
icu=58.2=h0a44026_3
intel-openmp=2021.2.0=hecd8cb5_564
jpeg=9b=he5867d9_2
lame=3.100=h1de35cc_0
lcms2=2.12=hf1fd2bf_0
libcxx=10.0.0=1
libffi=3.3=hb1e8313_2
libiconv=1.16=h1de35cc_0
libidn2=2.3.1=h9ed2024_0
libpng=1.6.37=ha441bb4_0
libprotobuf=3.14.0=h2842e9f_0
libtasn1=4.16.0=h9ed2024_0
libtiff=4.2.0=h87d7836_0
libunistring=0.9.10=h9ed2024_0
libuv=1.40.0=haf1e3a3_0
libwebp-base=1.2.0=h9ed2024_0
libxml2=2.9.10=h7cdb67c_3
llvm-openmp=10.0.0=h28b9765_0
lz4-c=1.9.3=h23ab428_0
mkl=2021.2.0=hecd8cb5_269
mkl-service=2.3.0=py39h9ed2024_1
mkl_fft=1.3.0=py39h4a7008c_2
mkl_random=1.2.1=py39hb2f4e1b_2
ncurses=6.2=h0a44026_1
nettle=3.7.3=h230ac6f_1
ninja=1.10.2=hf7b0b51_1
numpy=1.20.2=py39h4b4dc7a_0
numpy-base=1.20.2=py39he0bd621_0
olefile=0.46=py_0
openh264=2.1.0=hd9629dc_0
openssl=1.1.1k=h0d85af4_0
pillow=8.2.0=py39h5270095_0
pip=21.1.1=py39hecd8cb5_0
protobuf=3.14.0=py39h23ab428_1
python=3.9.5=h88f2d9e_3
python_abi=3.9=1_cp39
pytorch=1.8.1=py3.9_0
readline=8.1=h9ed2024_0
setuptools=52.0.0=py39hecd8cb5_0
six=1.15.0=py39hecd8cb5_0
sqlite=3.35.4=hce871da_0
tk=8.6.10=hb0a8c7a_0
torchaudio=0.8.1=py39
torchvision=0.9.1=py39_cpu
typing_extensions=3.7.4.3=pyha847dfd_0
tzdata=2020f=h52ac0ba_0
wheel=0.36.2=pyhd3eb1b0_0
xz=5.2.5=h1de35cc_0
zlib=1.2.11=h1de35cc_3
zstd=1.4.9=h322a384_0
```