### PR TITLE
Adding infinite switch for multirecord dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ data = next(iter(loader))
 print(data)
 ```
 
+### Infinite and finite PyTorch dataset
+
+By default, `MultiTFRecordDataset` is infinite, meaning that it samples the data forever. You can make it finite by providing proper flag
+```
+dataset = MultiTFRecordDataset(...,infinite=False)
+```
+
 ### Shuffling the data
 
 Both TFRecordDataset and MultiTFRecordDataset automatically shuffle the data when you provide a queue size.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ print(data)
 
 By default, `MultiTFRecordDataset` is infinite, meaning that it samples the data forever. You can make it finite by providing proper flag
 ```
-dataset = MultiTFRecordDataset(...,infinite=False)
+dataset = MultiTFRecordDataset(..., infinite=False)
 ```
 
 ### Shuffling the data

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ print(data)
 
 ### Infinite and finite PyTorch dataset
 
-By default, `MultiTFRecordDataset` is infinite, meaning that it samples the data forever. You can make it finite by providing proper flag
+By default, `MultiTFRecordDataset` is infinite, meaning that it samples the data forever. You can make it finite by providing the appropriate flag
 ```
 dataset = MultiTFRecordDataset(..., infinite=False)
 ```

--- a/tfrecord/iterator_utils.py
+++ b/tfrecord/iterator_utils.py
@@ -46,16 +46,13 @@ def sample_iterators(iterators: typing.List[typing.Iterator],
     ratios = ratios / ratios.sum()
     while iterators:
         choice = np.random.choice(len(ratios), p=ratios)
-        if infinite:
+        try:
             yield next(iterators[choice])
-        else:
-            try:
-                yield next(iterators[choice])
-            except StopIteration:
-                if len(iterators) > 1:
-                    del iterators[choice]
-                    ratios = np.delete(ratios, choice)
-                    ratios = ratios / ratios.sum()
+        except StopIteration:
+            if len(iterators) > 1:
+                del iterators[choice]
+                ratios = np.delete(ratios, choice)
+                ratios = ratios / ratios.sum()
 
 
 

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -397,6 +397,7 @@ def multi_tfrecord_loader(data_pattern: str,
                           description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                           sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                           compression_type: typing.Optional[str] = None,
+                          infinite: bool = True,
                           ) -> typing.Iterable[typing.Union[typing.Dict[str, np.ndarray],
                                                             typing.Tuple[typing.Dict[str, np.ndarray],
                                                                          typing.Dict[str, typing.List[np.ndarray]]]]]:
@@ -435,6 +436,9 @@ def multi_tfrecord_loader(data_pattern: str,
     compression_type: str, optional, default=None
         The type of compression used for the tfrecord. Choose either
         'gzip' or None.
+    
+    infinite: bool, optional, default=True
+        Whether the returned iterator should be infinite or not
 
     Returns:
     --------
@@ -449,4 +453,4 @@ def multi_tfrecord_loader(data_pattern: str,
                                  compression_type=compression_type,
                                  )
                for split in splits.keys()]
-    return iterator_utils.sample_iterators(loaders, list(splits.values()))
+    return iterator_utils.sample_iterators(loaders, list(splits.values()), infinite=infinite)

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -135,6 +135,9 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
     compression_type: str, optional, default=None
         The type of compression used for the tfrecord. Choose either
         'gzip' or None.
+    
+    infinite: bool, optional, default=True
+        Whether the Dataset should be infinite or not
     """
 
     def __init__(self,
@@ -146,6 +149,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
                  transform: typing.Callable[[dict], typing.Any] = None,
                  sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
                  compression_type: typing.Optional[str] = None,
+                 infinite: bool = True
                  ) -> None:
         super(MultiTFRecordDataset, self).__init__()
         self.data_pattern = data_pattern
@@ -156,6 +160,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
         self.shuffle_queue_size = shuffle_queue_size
         self.transform = transform
         self.compression_type = compression_type
+        self.infinite = infinite
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -167,6 +172,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
                                           description=self.description,
                                           sequence_description=self.sequence_description,
                                           compression_type=self.compression_type,
+                                          infinite=self.infinite,
                                          )
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)


### PR DESCRIPTION
Hi, this PR adds switch in order to control whether `MultiTFRecordDataset` samples infinitely or not. Judging by couple issues opened on this topic, I figured this might be useful to make public.