### PR TITLE
allow to switch off automatic seeding of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,19 @@ data = next(iter(loader))
 print(data)
 ```
 
+### Seeding workers
+
+By default, `MultiTFRecordDataset` and `TFRecordDataset` seed workers, that are spawned by PyTorch in `DataLoader`.
+This behavior can be turned off by providing the appropriate flag.
+
+```python
+dataset = TFRecordDataset(..., seed_workers=False)
+```
+
 ### Infinite and finite PyTorch dataset
 
 By default, `MultiTFRecordDataset` is infinite, meaning that it samples the data forever. You can make it finite by providing the appropriate flag
-```
+```python
 dataset = MultiTFRecordDataset(..., infinite=False)
 ```
 


### PR DESCRIPTION
Hi,

another PR, this time for ability to switch off automatic seeding of workers. If a user has in place some other mechanism of seeding workers (such as by `worker_init_fn` in `DataLoader`), current seeding interferes with it and this PR adds a switch to not seed workers.