### PR TITLE
fix calculating file size for zipped records. remove hardcoded bytes->numpy conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages
 install_requires = []
 if sys.version_info <= (2, 7):
     install_requires += ['future', 'typing']
-install_requires += ['numpy', 'protobuf', 'crc32c']
+install_requires += ['numpy', 'protobuf==3.19.3', 'crc32c']
 
 # read the contents of README file
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -57,10 +57,11 @@ def tfrecord_iterator(
     def read_records(start_offset=None, end_offset=None):
         nonlocal length_bytes, crc_bytes, datum_bytes
 
-        if start_offset is not None:
-            file.seek(start_offset)
         if end_offset is None:
-            end_offset = os.path.getsize(data_path)
+            end_offset = file.seek(0, io.SEEK_END)
+        if start_offset is None:
+            start_offset = 0
+        file.seek(start_offset)
         while file.tell() < end_offset:
             if file.readinto(length_bytes) != 8:
                 raise RuntimeError("Failed to read the record size.")
@@ -113,7 +114,7 @@ def process_feature(feature: example_pb2.Feature,
                         f"(should be '{reversed_mapping[inferred_typename]}').")
 
     if inferred_typename == "bytes_list":
-        value = np.frombuffer(value[0], dtype=np.uint8)
+        value = value[0]
     elif inferred_typename == "float_list":
         value = np.array(value, dtype=np.float32)
     elif inferred_typename == "int64_list":


### PR DESCRIPTION
The first alteration fixes the bug in reading zipped tfrecords. The library computed the size of a zipped file instead of unarchived data, because of which only a part of a file was read. 

The second update is for users' convenience. I've removed the hardcoded conversion of bytes list to uint8 numpy array, because the original data might not be encoded in uint8 like in my case where I had the original type of uint16. This led to the fact that the samples arrays read were twice as big and distorted, and I had to convert them back to bytes and to uint16 numpy array to fix the problem. I don't think that hardcoded conversion is really needed, because it still doesn't restore the original shape of a tensor, so users still have to do their own postprocessing. So I suggest removing it at all to leave this task of loading and processing bytes to the client-side.