### PR TITLE
Get the original file size when the file is a gzip format file

### DIFF
--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -54,13 +54,18 @@ def tfrecord_iterator(
     crc_bytes = bytearray(4)
     datum_bytes = bytearray(1024 * 1024)
 
+    def gzip_file_size(filename):
+        with gzip.open(filename, "rb") as fd:
+            fd.seek(0, io.SEEK_END)
+            return fd.tell()
+
     def read_records(start_offset=None, end_offset=None):
         nonlocal length_bytes, crc_bytes, datum_bytes
 
         if start_offset is not None:
             file.seek(start_offset)
         if end_offset is None:
-            end_offset = os.path.getsize(data_path)
+            end_offset = gzip_file_size(data_path) if compression_type == 'gzip' else os.path.getsize(data_path)
         while file.tell() < end_offset:
             if file.readinto(length_bytes) != 8:
                 raise RuntimeError("Failed to read the record size.")


### PR DESCRIPTION
When using the tfrecord library to read the tfrecord file in gzip format, I found a problem, I can't read all the data. Looking at the code, I found that when the program obtained the input data size and read the data as an index, it did not distinguish whether it was a gizp compressed file. This was a bug. This bug was fixed with this pull request and the test passed.