### PR TITLE
reader now supports .send() syntax for specifying index

### DIFF
--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -108,7 +108,7 @@ def tfrecord_iterator(
         yield from read_records()
     else:
         if shard is None:
-            offset = index[0]
+            offset = np.random.choice(index)
             yield from read_records(offset)
             yield from read_records(0, offset)
         else:

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -8,6 +8,107 @@ import torch.utils.data
 from tfrecord import iterator_utils, reader
 
 
+class TFRecordMapDataset(torch.utils.data.Dataset):
+    """Parse (generic) TFRecords dataset into `Dataset` object,
+    which contain `np.ndarrays`s. By default (when `sequence_description`
+    is None), it treats the TFRecords as containing `tf.Example`.
+    Otherwise, it assumes it is a `tf.SequenceExample`.
+
+    Params:
+    -------
+    data_path: str
+        The path to the tfrecords file.
+
+    index_path: str
+        The path to the index file. Necessary for TFRecordMapDataset
+
+    description: list or dict of str, optional, default=None
+        List of keys or dict of (key, value) pairs to extract from each
+        record. The keys represent the name of the features and the
+        values ("byte", "float", or "int") correspond to the data type.
+        If dtypes are provided, then they are verified against the
+        inferred type for compatibility purposes. If None (default),
+        then all features contained in the file are extracted.
+
+    shuffle_queue_size: int, optional, default=None
+        Length of buffer. Determines how many records are queued to
+        sample from.
+
+    transform : a callable, default = None
+        A function that takes in the input `features` i.e the dict
+        provided in the description, transforms it and returns a
+        desirable output.
+
+    sequence_description: list or dict of str, optional, default=None
+        Similar to `description`, but refers to the sequence features
+        within a `SequenceExample`. When this field is `None`, then it
+        is assumed that an `Example` is being read otherwise, a
+        `SequenceExample` is read. If an empty list or dictionary is
+        passed, then all features contained in the file are extracted.
+
+    compression_type: str, optional, default=None
+        The type of compression used for the tfrecord. Choose either
+        'gzip' or None.
+
+    """
+
+    def __init__(
+        self,
+        data_path: str,
+        index_path: str,
+        description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+        shuffle_queue_size: typing.Optional[int] = None,
+        transform: typing.Callable[[dict], typing.Any] = None,
+        sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
+        compression_type: typing.Optional[str] = None,
+    ) -> None:
+        super(TFRecordMapDataset, self).__init__()
+        self.data_path = data_path
+        self.index_path = index_path
+        self.description = description
+        self.sequence_description = sequence_description
+        self.shuffle_queue_size = shuffle_queue_size
+        self.transform = transform or (lambda x: x)
+        self.compression_type = compression_type
+        self.index = np.loadtxt(index_path, dtype=np.int64)[:, 0]
+        self.it = None 
+
+    def _close(self):
+        self.it.send(-1)
+
+    def __getitem__(self, index):
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            shard = worker_info.id, worker_info.num_workers
+            np.random.seed(worker_info.seed % np.iinfo(np.uint32).max)
+        else:
+            shard = None
+
+        if self.it is None:
+            self.it = reader.tfrecord_loader(
+                data_path=self.data_path,
+                index_path=self.index_path,
+                description=self.description,
+                shard=shard,
+                sequence_description=self.sequence_description,
+                compression_type=self.compression_type,
+            )
+            next(self.it)
+        if self.shuffle_queue_size:
+            self.it = iterator_utils.shuffle_iterator(self.it, self.shuffle_queue_size)
+        record = self.it.send(index)
+        if self.transform:
+            record = self.transform(record)
+        return record
+
+    def __len__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            shard = worker_info.id, worker_info.num_workers
+        else:
+            shard = 0, 1 
+        return len(self.index) / shard[1]
+
 class TFRecordDataset(torch.utils.data.IterableDataset):
     """Parse (generic) TFRecords dataset into `IterableDataset` object,
     which contain `np.ndarrays`s. By default (when `sequence_description`

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -97,10 +97,7 @@ class TFRecordMapDataset(torch.utils.data.Dataset):
                 compression_type=self.compression_type,
                 map_access=True,
             )
-            try:
-                next(self.it)
-            except:
-                pass
+            next(self.it)
             self.initialized = True
 
         if self.shuffle_queue_size:

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -71,43 +71,51 @@ class TFRecordMapDataset(torch.utils.data.Dataset):
         self.transform = transform or (lambda x: x)
         self.compression_type = compression_type
         self.index = np.loadtxt(index_path, dtype=np.int64)[:, 0]
-        self.it = None 
+        self.initialized = False
+        self.shard = None
+        self.it = None
 
     def _close(self):
-        self.it.send(-1)
+        if self.it is not None:
+            self.it.send(-1)
 
     def __getitem__(self, index):
-        worker_info = torch.utils.data.get_worker_info()
-        if worker_info is not None:
-            shard = worker_info.id, worker_info.num_workers
-            np.random.seed(worker_info.seed % np.iinfo(np.uint32).max)
-        else:
-            shard = None
+        if self.initialized is False:
+            worker_info = torch.utils.data.get_worker_info()
+            if worker_info is not None:
+                self.shard = worker_info.id, worker_info.num_workers
+                np.random.seed(worker_info.seed % np.iinfo(np.uint32).max)
+            else:
+                self.shard = None
 
-        if self.it is None:
             self.it = reader.tfrecord_loader(
                 data_path=self.data_path,
                 index_path=self.index_path,
                 description=self.description,
-                shard=shard,
+                shard=self.shard,
                 sequence_description=self.sequence_description,
                 compression_type=self.compression_type,
+                map_access=True,
             )
-            next(self.it)
+            try:
+                next(self.it)
+            except:
+                pass
+            self.initialized = True
+
         if self.shuffle_queue_size:
             self.it = iterator_utils.shuffle_iterator(self.it, self.shuffle_queue_size)
+
         record = self.it.send(index)
         if self.transform:
             record = self.transform(record)
         return record
 
     def __len__(self):
-        worker_info = torch.utils.data.get_worker_info()
-        if worker_info is not None:
-            shard = worker_info.id, worker_info.num_workers
+        if self.shard is None:
+            return len(self.index)
         else:
-            shard = 0, 1 
-        return len(self.index) / shard[1]
+            return len(self.index) / self.shard[1]
 
 class TFRecordDataset(torch.utils.data.IterableDataset):
     """Parse (generic) TFRecords dataset into `IterableDataset` object,


### PR DESCRIPTION
reader now supports .send() syntax for specifying index, MapDataset sets up iterator and uses it with .send()

retry of https://github.com/vahidk/tfrecord/pull/96

I added .send() functionality to reader to let it seek to somewhere in the index before returning a value. I added a TFRecordMapDataset that creates the generate and calls an initial next() on it to get one value and then is capable of setting indices.

Dataset requires a .tfindex has been built. 