### PR TITLE
Fix a bug where `MultiTFRecordDataset(infinite=False)` reads the records multiple times

### DIFF
--- a/tests/test_multi_tf_record_dataset.py
+++ b/tests/test_multi_tf_record_dataset.py
@@ -1,0 +1,106 @@
+from contextlib import contextmanager
+import unittest
+import tempfile
+
+import numpy as np
+from torch.utils.data import DataLoader
+
+from tfrecord import example_pb2
+from tfrecord.reader import process_feature
+from tfrecord.torch.dataset import MultiTFRecordDataset
+from tfrecord.writer import TFRecordWriter
+from tfrecord.tools.tfrecord2idx import create_index
+
+
+@contextmanager
+def write_tfrecord_with_index(records):
+    with tempfile.NamedTemporaryFile(delete=False) as record_temp_file, tempfile.NamedTemporaryFile(delete=False) as index_temp_file:
+        record_file = record_temp_file.name
+        index_file = index_temp_file.name
+        writer = TFRecordWriter(record_file)
+        for datum in records:
+            writer.write(datum)
+        writer.close()
+        create_index(record_file, f"{record_file}.idx")
+        yield record_file
+
+
+class TestMultiTFRecordDataset(unittest.TestCase):
+
+    def test_has_correct_number_of_records_with_any_number_of_process(self):
+        """
+        Test that the MultiTFRecordDataset generates the correct number of records
+        when running in a single process or in multiple processes (num_workers >= 2).
+        """
+        with (
+            write_tfrecord_with_index([{"key": (b"1", "byte")}]*1000) as record_file_1,
+            write_tfrecord_with_index([{"key": (b"2", "byte")}]*1000) as record_file_2
+        ):
+            record_pattern = "{}"
+            index_pattern = "{}.idx"
+            # Note that the split does not matter so much in the infinite=False case, 
+            # the iterator will stop when all records are read, the split will just
+            # influence the order in which the records are read.
+            split = {
+                record_file_1: 0.8,
+                record_file_2: 0.2
+            }
+            dataset = MultiTFRecordDataset(
+                record_pattern,
+                index_pattern,
+                split,
+                infinite=False
+            )
+            for num_workers in [0, 2, 8]:
+                with self.subTest("num_workers", num_workers=num_workers):
+                    total_records = 0
+                    loader = DataLoader(dataset, batch_size=9, num_workers=num_workers)
+                    for batch in loader:
+                        total_records += len(batch["key"])
+
+                    self.assertEqual(total_records, 2000)
+
+    def test_samples_correctly_with_any_number_of_processes(self):
+        """
+        Test that the MultiTFRecordDataset generates records with the correct sampling 
+        ratio when running in single or multiple processes (num_workers >= 2).
+        """
+        with (
+            write_tfrecord_with_index([{"key": (b"1", "byte")}]*1000) as record_file_1,
+            write_tfrecord_with_index([{"key": (b"2", "byte")}]*1000) as record_file_2
+        ):
+            record_pattern = "{}"
+            index_pattern = "{}.idx"
+            split = {
+                record_file_1: 0.8,
+                record_file_2: 0.2
+            }
+            dataset = MultiTFRecordDataset(
+                record_pattern,
+                index_pattern,
+                split,
+                infinite=True
+            )
+            for num_workers in [0, 2, 8]:
+                with self.subTest("num_workers", num_workers=num_workers):
+                    total_records = 0
+                    key_1_count = 0
+                    key_2_count = 0
+                    loader = DataLoader(dataset, batch_size=9, num_workers=num_workers)
+
+                    for batch in loader:
+                        total_records += len(batch["key"])
+                        key_1_count += np.sum(np.array(batch["key"]) == b"1")
+                        key_2_count += np.sum(np.array(batch["key"]) == b"2")
+                        if total_records > 2000:
+                            break
+                        
+                    self.assertGreater(total_records, 2000)
+                    # Those assertions have each a ~1e-8 probability of failing because 
+                    # the sampling is random.
+                    self.assertTrue(0.75 < key_1_count / total_records < 0.85)
+                    self.assertTrue(0.15 < key_2_count / total_records < 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tfrecord/reader.py
+++ b/tfrecord/reader.py
@@ -394,6 +394,7 @@ def multi_tfrecord_loader(
     sequence_description: typing.Union[typing.List[str], typing.Dict[str, str], None] = None,
     compression_type: typing.Optional[str] = None,
     infinite: bool = True,
+    shard: typing.Optional[typing.Tuple[int, int]] = None
 ) -> typing.Iterable[
     typing.Union[
         typing.Dict[str, np.ndarray],
@@ -401,8 +402,6 @@ def multi_tfrecord_loader(
     ]
 ]:
     """Create an iterator by reading and merging multiple tfrecord datasets.
-
-    NOTE: Sharding is currently unavailable for the multi tfrecord loader.
 
     Params:
     -------
@@ -439,6 +438,11 @@ def multi_tfrecord_loader(
     infinite: bool, optional, default=True
         Whether the returned iterator should be infinite or not
 
+    shard: tuple of ints, optional, default=None
+        A tuple (index, count) representing worker_id and num_workers
+        count. Necessary to evenly split/shard the dataset among many
+        workers (i.e. >1).
+
     Returns:
     --------
     it: iterator
@@ -452,6 +456,7 @@ def multi_tfrecord_loader(
             description=description,
             sequence_description=sequence_description,
             compression_type=compression_type,
+            shard=shard
         )
         for split in splits.keys()
     ]

--- a/tfrecord/torch/dataset.py
+++ b/tfrecord/torch/dataset.py
@@ -167,8 +167,10 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
+        shard = None
         if worker_info is not None:
             np.random.seed(worker_info.seed % np.iinfo(np.uint32).max)
+            shard = worker_info.id, worker_info.num_workers
         it = reader.multi_tfrecord_loader(
             data_pattern=self.data_pattern,
             index_pattern=self.index_pattern,
@@ -177,6 +179,7 @@ class MultiTFRecordDataset(torch.utils.data.IterableDataset):
             sequence_description=self.sequence_description,
             compression_type=self.compression_type,
             infinite=self.infinite,
+            shard=shard,
         )
         if self.shuffle_queue_size:
             it = iterator_utils.shuffle_iterator(it, self.shuffle_queue_size)


### PR DESCRIPTION
When `infinite=False`, we would expect the `MultiTFRecordDataset` to yield each tfrecord file once only. This was not the case because sharding was not enabled for `MultiTFRecordDataset`, so each process would go through each tfrecord file once.

Without this change the test `test_has_correct_number_of_records_with_any_number_of_process` fails for 2 or 8 processes:

```bash
> python run_tests.py 
FF.........
======================================================================
FAIL: test_has_correct_number_of_records_with_any_number_of_process (test_multi_tf_record_dataset.TestMultiTFRecordDataset.test_has_correct_number_of_records_with_any_number_of_process) [num_workers] (num_workers=2)
Test that the MultiTFRecordDataset generates the correct number of records
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/quentinbernard/Documents/Dev/merging-v2/tfrecord/tests/test_multi_tf_record_dataset.py", line 61, in test_has_correct_number_of_records_with_any_number_of_process
    self.assertEqual(total_records, 2000)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
AssertionError: 4000 != 2000

======================================================================
FAIL: test_has_correct_number_of_records_with_any_number_of_process (test_multi_tf_record_dataset.TestMultiTFRecordDataset.test_has_correct_number_of_records_with_any_number_of_process) [num_workers] (num_workers=8)
Test that the MultiTFRecordDataset generates the correct number of records
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/quentinbernard/Documents/Dev/merging-v2/tfrecord/tests/test_multi_tf_record_dataset.py", line 61, in test_has_correct_number_of_records_with_any_number_of_process
    self.assertEqual(total_records, 2000)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
AssertionError: 16000 != 2000
```

I enabled sharding and added tests to make sure sampling works correctly, and that we read the dataset only once.